### PR TITLE
Fix acceptance specs

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'bundler/setup'
-require 'resque/uniqueness'
+require 'resque/plugins/uniqueness'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/resque-uniqueness.rb
+++ b/lib/resque-uniqueness.rb
@@ -1,0 +1,1 @@
+require_relative 'resque/plugins/uniqueness'

--- a/lib/resque/plugins/uniqueness.rb
+++ b/lib/resque/plugins/uniqueness.rb
@@ -71,15 +71,6 @@ module Resque
           base.extend ClassMethods
         end
 
-        # We should to handle exception here to prevent run after hooks.
-        # Read more info `Resque::Plugins::Uniqueness::JobExtension.create` and
-        # and `Resque::Plugins::Uniqueness::JobExtension.parent_handle_locking_error?`
-        def enqueue_to(queue, klass, *args)
-          super
-        rescue LockingError
-          nil
-        end
-
         # Resque uses `Resque.pop(queue)` for retrieving jobs from queue, but in case when we have
         # while_executing lock we should to be sure that we popped unlocked job.
         # That's why we should to check lock of popped job, and if its locked - push it back.

--- a/lib/resque/plugins/uniqueness.rb
+++ b/lib/resque/plugins/uniqueness.rb
@@ -71,6 +71,15 @@ module Resque
           base.extend ClassMethods
         end
 
+        # We should to handle exception here to prevent run after hooks.
+        # Read more info `Resque::Plugins::Uniqueness::JobExtension.create` and
+        # and `Resque::Plugins::Uniqueness::JobExtension.parent_handle_locking_error?`
+        def enqueue_to(queue, klass, *args)
+          super
+        rescue LockingError
+          nil
+        end
+
         # Resque uses `Resque.pop(queue)` for retrieving jobs from queue, but in case when we have
         # while_executing lock we should to be sure that we popped unlocked job.
         # That's why we should to check lock of popped job, and if its locked - push it back.

--- a/lib/resque/plugins/uniqueness.rb
+++ b/lib/resque/plugins/uniqueness.rb
@@ -71,17 +71,6 @@ module Resque
           base.extend ClassMethods
         end
 
-        # Remove all performing keys from redis.
-        # Using to fix unexpected terminated problem.
-        def clear_performing_locks
-          cursor = '0'
-          loop do
-            cursor, keys = Resque.redis.scan(cursor, match: "#{WhileExecuting::PREFIX}:#{REDIS_KEY_PREFIX}:*")
-            Resque.redis.del(*keys) if keys.any?
-            break if cursor.to_i.zero?
-          end
-        end
-
         # Resque uses `Resque.pop(queue)` for retrieving jobs from queue, but in case when we have
         # while_executing lock we should to be sure that we popped unlocked job.
         # That's why we should to check lock of popped job, and if its locked - push it back.
@@ -213,6 +202,3 @@ module Resque
     end
   end
 end
-
-# Clear all performing locks from redis (could be present because of unexpected terminated)
-Resque::Plugins::Uniqueness.clear_performing_locks

--- a/lib/resque/plugins/uniqueness/resque_extension.rb
+++ b/lib/resque/plugins/uniqueness/resque_extension.rb
@@ -13,6 +13,15 @@ module Resque
 
         # Class methods for override base Resque module
         module ClassMethods
+          # We should to handle exception here to prevent run after hooks.
+          # Read more info `Resque::Plugins::Uniqueness::JobExtension.create` and
+          # and `Resque::Plugins::Uniqueness::JobExtension.parent_handle_locking_error?`
+          def enqueue_to(queue, klass, *args)
+            super
+          rescue LockingError
+            nil
+          end
+
           def remove_queue(queue)
             super.tap { Resque::Plugins::Uniqueness.remove_queue(queue) unless Resque.inline? }
           end

--- a/lib/resque/plugins/uniqueness/resque_scheduler_extension.rb
+++ b/lib/resque/plugins/uniqueness/resque_scheduler_extension.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Resque
+  module Plugins
+    module Uniqueness
+      # Extension for Resque Scheduler
+      # We prepend it to resque module and override `delayed_push` and `enqueue_at_with_queue`
+      # methods from `Resque::Scheduler::DelayingExtensions`
+      # for allowing locks to work in multithreading.
+      module ResqueSchedulerExtension
+        def self.prepended(base)
+          class << base
+            prepend ClassMethods
+          end
+        end
+
+        # Class methods for overriding ResqueScheduler behavior
+        module ClassMethods
+          # Override Resque::Scheduler::DelayingExtensions.enqueue_at_with_queue method
+          # See more info in comments for
+          # `Resque::Plugins::Uniqueness::ResqueSchedulerExtension.delayed_push` method
+          def enqueue_at_with_queue(queue, timestamp, klass, *args)
+            super
+            # Exception could be raised in
+            # `Resque::Plugins::Uniqueness::ResqueSchedulerExtension.delayed_push`
+          rescue LockingError
+            false
+          end
+
+          # Override Resque::Scheduler::DelayingExtensions.delayed_push
+          # We couldn't lock job in the after hook, because of multithreading app can take same jobs
+          # at the same time, and only on locking one from them will raise exception.
+          # But it will be after the thread will put job to the schedule.
+          #
+          # We couldn't lock job in the before hook as well, because of next hooks can return false
+          # and the job will have lock, but not been scheduled.
+          def delayed_push(timestamp, item)
+            # This line could raise `LockingError` and it should be handled in the
+            # `enqueue_at_with_queue` method
+            #
+            # We can't handle exception here, because of jobs, which raise an error on locking
+            # will run after hooks, but its unexpected behavior.
+            Resque::Job.new(item[:queue], 'class' => item[:class], 'args' => item[:args])
+                       .uniqueness
+                       .try_lock_queueing
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/resque/plugins/uniqueness/until_executing.rb
+++ b/lib/resque/plugins/uniqueness/until_executing.rb
@@ -23,9 +23,10 @@ module Resque
         end
 
         def lock_queueing
-          raise LockingError, 'Job is already locked on queueing' if queueing_locked?
+          value_before = redis.getset(redis_key, 1)
 
-          redis.incr(redis_key)
+          # If value before is postive, than lock already present
+          raise LockingError, 'Job is already locked on queueing' if value_before.to_i.positive?
         end
 
         def unlock_queueing

--- a/lib/resque/plugins/uniqueness/while_executing.rb
+++ b/lib/resque/plugins/uniqueness/while_executing.rb
@@ -29,7 +29,6 @@ module Resque
 
         def lock_perform
           value_before = redis.getset(redis_key, 1)
-          value_before = 1
 
           # If value before is postive, than lock already present
           raise LockingError, 'Job is already locked on perform' if value_before.to_i.positive?

--- a/lib/resque/plugins/uniqueness/while_executing.rb
+++ b/lib/resque/plugins/uniqueness/while_executing.rb
@@ -25,9 +25,10 @@ module Resque
         end
 
         def lock_perform
-          raise LockingError, 'Job is already locked on perform' if perform_locked?
+          value_before = redis.getset(redis_key, 1)
 
-          redis.incr(redis_key)
+          # If value before is postive, than lock already present
+          raise LockingError, 'Job is already locked on perform' if value_before.to_i.positive?
         end
 
         def unlock_perform

--- a/spec/resque/plugins/uniqueness/job_extension_spec.rb
+++ b/spec/resque/plugins/uniqueness/job_extension_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Resque::Plugins::Uniqueness::JobExtension do
     let(:job_payload) { {'class' => UntilAndWhileExecutingWorker, 'args' => args} }
     let(:args) { [] }
 
-    before { allow(Resque::Plugins::Uniqueness).to receive(:pop_perform_unlocked_from_queue).and_return(job) }
+    before { allow(Resque::Plugins::Uniqueness).to receive(:pop_perform_unlocked).and_return(job) }
 
     its_block { is_expected.to send_message(lock_instance, :ensure_unlock_queueing) }
     its_block { is_expected.to send_message(lock_instance, :try_lock_perform) }

--- a/spec/resque/plugins/uniqueness_spec.rb
+++ b/spec/resque/plugins/uniqueness_spec.rb
@@ -169,8 +169,8 @@ RSpec.describe Resque::Plugins::Uniqueness do
 
   ### Specs for class methods
 
-  describe '.pop_perform_unlocked_from_queue' do
-    subject(:unlocked_job) { described_class.pop_perform_unlocked_from_queue(queue) }
+  describe '.pop_perform_unlocked' do
+    subject(:unlocked_job) { described_class.pop_perform_unlocked(queue) }
 
     include_context 'with lock', :perform_locked
     let(:lock_class) { Resque::Plugins::Uniqueness::WhileExecuting }
@@ -192,27 +192,6 @@ RSpec.describe Resque::Plugins::Uniqueness do
     it 'returns correct job and remove it from redis list', :aggregate_failures do
       expect(unlocked_job).to eq Resque::Job.new(queue, Resque.decode(encoded_jobs.last))
       expect(Resque.redis.lrange(queue_key, 0, -1)).to match_array encoded_jobs[0..-2]
-    end
-  end
-
-  describe '.unperform_unlocked?' do
-    subject { described_class.can_be_performed?(encoded_job) }
-
-    include_context 'with lock', :perform_locked
-    let(:lock_class) { Resque::Plugins::Uniqueness::WhileExecuting }
-    let(:job) { {class: WhileExecutingWorker, args: job_args} }
-    let(:encoded_job) { Resque.encode(job) }
-
-    context 'when job is locked' do
-      let(:job_args) { [:perform_locked] }
-
-      it { is_expected.to be false }
-    end
-
-    context 'when job is unlocked' do
-      let(:job_args) { [:unlocked] }
-
-      it { is_expected.to be true }
     end
   end
 

--- a/spec/resque/plugins/uniqueness_spec.rb
+++ b/spec/resque/plugins/uniqueness_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe Resque::Plugins::Uniqueness do
     let(:args) { ['queueing_locked'] }
 
     it { is_expected.to be false }
-    its_block { is_expected.not_to send_message(lock_instance, :try_lock_queueing) }
 
     context 'when resque inline' do
       around do |example|
@@ -59,14 +58,12 @@ RSpec.describe Resque::Plugins::Uniqueness do
       end
 
       it { is_expected.to be true }
-      its_block { is_expected.not_to send_message(lock_instance, :try_lock_queueing) }
     end
 
     context 'when job is not locked' do
       let(:args) { ['unlocked'] }
 
       it { is_expected.to be true }
-      its_block { is_expected.to send_message(lock_instance, :try_lock_queueing) }
     end
   end
 

--- a/spec/resque/plugins/uniqueness_spec.rb
+++ b/spec/resque/plugins/uniqueness_spec.rb
@@ -255,22 +255,4 @@ RSpec.describe Resque::Plugins::Uniqueness do
       its_block { is_expected.to send_message(lock_instance, :ensure_unlock_queueing).once }
     end
   end
-
-  describe '.clear_performing_locks' do
-    subject(:call) { described_class.clear_performing_locks }
-
-    before do
-      stub_const('Resque::Plugins::Uniqueness::WhileExecuting::PREFIX', 'performing')
-      stub_const('Resque::Plugins::Uniqueness::REDIS_KEY_PREFIX', 'redis_key_prefix')
-
-      5.times { Resque.redis.incr("#{key_prefix}#{SecureRandom.uuid}") }
-    end
-
-    let(:key_prefix) { "#{Resque::Plugins::Uniqueness::WhileExecuting::PREFIX}:#{Resque::Plugins::Uniqueness::REDIS_KEY_PREFIX}:" }
-
-    it 'not include any performing keys' do
-      call
-      expect(Resque.redis.keys).not_to include(/#{key_prefix}/)
-    end
-  end
 end


### PR DESCRIPTION
Fixed acceptance specs (their fails approximately 4 from 100)
We have problems with `evrything_in_queue` method when we try to find a job without performing lock.
Resque runs workers in different threads, and we could have a case when two threads starting to process one job. 

`while_executing` fails because two threads can take one job twice, that's why the first time we remove the correct job, but in the second one, it duplicates. And also, in that case, we process two jobs at the same time. (which is not expected behavior)

`until_executing` fails, because we could have only one job in the queue, but two threads pick up it at the same time and starting to process it.

We should remove the solution with `evrything_in_queue` and make it through `Resque.pop` and push it back when the job has a lock.

Also, we should remove `after_schedule` hook to prevent multiple threads schedule two same jobs. 
In case when we try locking queueing in the after hook, we can't correct handle exception because the job was already scheduled. For now, we lock job in overridden `delayed_push` method and handle lock exception in overridden `enqueue_at_with_queue` method.