### PR TITLE
HOTFIX: fix bug with invalid jobs

### DIFF
--- a/lib/resque/plugins/uniqueness/job_extension.rb
+++ b/lib/resque/plugins/uniqueness/job_extension.rb
@@ -19,6 +19,10 @@ module Resque
           # We should to ignore locking when this method call from scheduler.
           # More information read in the description of `lib.resque_ext/plugin/scheduler_unique_job.rb#call_from_scheduler?` method
           def create(queue, klass, *args)
+            # This validate also present in super version of this method, but for be sure
+            # that we don't to lock unvalid jobs, we duplicate this validation here
+            Resque.validate(klass, queue)
+
             return super if skip_uniqueness_on_create?(klass)
 
             job = new(queue, 'class' => klass.to_s, 'args' => decode(encode(args)))

--- a/spec/resque/plugins/uniqueness/job_extension_spec.rb
+++ b/spec/resque/plugins/uniqueness/job_extension_spec.rb
@@ -61,6 +61,27 @@ RSpec.describe Resque::Plugins::Uniqueness::JobExtension do
       its_block { is_expected.not_to send_message(Resque, :push).with(queue, class: klass.to_s, args: args) }
       its_block { is_expected.not_to send_message(lock_instance, :try_lock_queueing) }
     end
+
+    context 'when queue missed in worker' do
+      let(:klass) { Class.new(TestWorker) }
+      let(:queue) {}
+
+      its_block do
+        is_expected.to raise_error(Resque::NoQueueError)
+          .and(not_to_send_message(Resque, :push))
+          .and(not_to_send_message(lock_instance, :try_lock_queueing))
+      end
+    end
+
+    context 'when klass is empty' do
+      let(:klass) { '' }
+
+      its_block do
+        is_expected.to raise_error(Resque::NoClassError)
+          .and(not_to_send_message(Resque, :push))
+          .and(not_to_send_message(lock_instance, :try_lock_queueing))
+      end
+    end
   end
 
   describe '.reserve' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,3 +21,5 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 end
+
+RSpec::Matchers.define_negated_matcher :not_to_send_message, :send_message


### PR DESCRIPTION
When the job is invalid (missed queue, for example), we lock queueing and after that receive an exception for the invalid job (it's mean don't put this job into queue). That's why we have lock, which never been released.