### PR TITLE
HOTFIX: creating redis key

### DIFF
--- a/lib/resque/plugins/uniqueness.rb
+++ b/lib/resque/plugins/uniqueness.rb
@@ -190,6 +190,8 @@ module Resque
         # We can't schedule two same jobs with `until_executing` lock.
         # That's why we sure, that all jobs, which comes from scheduler, should be processed.
         def call_from_scheduler?
+          # This path is from the `resque-scheduler` gem
+          # Its not related to resque-uniqueness.
           caller.grep(%r{lib/resque/scheduler\.rb.*enqueue}).any?
         end
 

--- a/lib/resque/plugins/uniqueness.rb
+++ b/lib/resque/plugins/uniqueness.rb
@@ -164,7 +164,7 @@ module Resque
         end
 
         # when perform fails Resque call this hook
-        def on_failure_check_unique_lock(*args)
+        def on_failure_check_unique_lock(_error, *args)
           create_job(args).uniqueness.ensure_unlock_perform
         end
 

--- a/lib/resque/plugins/uniqueness/base.rb
+++ b/lib/resque/plugins/uniqueness/base.rb
@@ -68,7 +68,7 @@ module Resque
         end
 
         def redis_key
-          "#{self.class::PREFIX}:#{REDIS_KEY_PREFIX}:#{Resque.encode(job.payload)}"
+          "#{self.class::PREFIX}:#{REDIS_KEY_PREFIX}:#{Resque.encode(class: job.payload_class, args: job.args)}"
         end
 
         def log(message)

--- a/spec/acceptance/resque/plugins/uniqueness_spec.rb
+++ b/spec/acceptance/resque/plugins/uniqueness_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe Resque::Plugins::Uniqueness do
     end
 
     it { is_expected.to eq output_result }
+
+    context 'when raise error on perform' do
+      let(:worker_class) { WhileExecutingPerformErrorWorker }
+
+      it { is_expected.to eq output_result }
+    end
   end
 
   describe 'until_executing' do
@@ -77,6 +83,12 @@ RSpec.describe Resque::Plugins::Uniqueness do
     end
 
     it { is_expected.to eq output_result }
+
+    context 'when raise error on perform' do
+      let(:worker_class) { UntilAndWhileExecutingPerformErrorWorker }
+
+      it { is_expected.to eq output_result }
+    end
   end
 
   def workers_waiter

--- a/spec/fixtures/test_workers.rb
+++ b/spec/fixtures/test_workers.rb
@@ -12,6 +12,7 @@ class TestWorker
   def self.perform(*args)
     before_processing(args)
     sleep 1
+    yield if block_given?
   ensure
     after_processing(args)
   end
@@ -46,6 +47,17 @@ class WhileExecutingWorker < TestWorker
   @queue = :test_job
 end
 
+class WhileExecutingPerformErrorWorker < TestWorker
+  @lock_type = :while_executing
+  @queue = :test_job
+
+  def self.perform(*args)
+    super do
+      raise 'test error'
+    end
+  end
+end
+
 class UntilExecutingWorker < TestWorker
   @lock_type = :until_executing
   @queue = :test_job
@@ -56,10 +68,21 @@ class UntilAndWhileExecutingWorker < TestWorker
   @queue = :test_job
 
   def self.perform(*args)
-    before_processing(args)
-    sleep 5
-  ensure
-    after_processing(args)
+    super do
+      sleep 4
+    end
+  end
+end
+
+class UntilAndWhileExecutingPerformErrorWorker < TestWorker
+  @lock_type = :until_and_while_executing
+  @queue = :test_job
+
+  def self.perform(*args)
+    super do
+      sleep 4
+      raise 'test error'
+    end
   end
 end
 

--- a/spec/resque/plugins/uniqueness/until_executing_spec.rb
+++ b/spec/resque/plugins/uniqueness/until_executing_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Resque::Plugins::Uniqueness::UntilExecuting do
-  let(:job) { Resque::Job.new(nil, 'class' => klass, args: []) }
+  let(:job) { Resque::Job.new(nil, 'class' => klass, 'args' => []) }
   let(:lock_instance) { described_class.new(job) }
   let(:redis_key) { lock_instance.send(:redis_key) }
   let(:klass) { UntilExecutingWorker }
@@ -61,6 +61,16 @@ RSpec.describe Resque::Plugins::Uniqueness::UntilExecuting do
         call
         expect(Resque.redis.get(redis_key)).to be_nil
       end
+    end
+  end
+
+  describe '#redis_key' do
+    subject { redis_key }
+
+    let(:job) { Resque::Job.new(nil, 'class' => klass, 'args' => [], 'queue' => 'test_queue') }
+
+    it 'not to save queue' do
+      is_expected.not_to match(/test_queue/)
     end
   end
 end

--- a/spec/resque/plugins/uniqueness/while_executing_spec.rb
+++ b/spec/resque/plugins/uniqueness/while_executing_spec.rb
@@ -63,4 +63,14 @@ RSpec.describe Resque::Plugins::Uniqueness::WhileExecuting do
       end
     end
   end
+
+  describe '#redis_key' do
+    subject { redis_key }
+
+    let(:job) { Resque::Job.new(nil, 'class' => klass, 'args' => [], 'queue' => 'test_queue') }
+
+    it 'not to save queue' do
+      is_expected.not_to match(/test_queue/)
+    end
+  end
 end


### PR DESCRIPTION
The payload in some cases could have a `queue` key. But we don't need it in resque locks.