### PR TITLE
HOTFIX: bug with scheduled jobs

### DIFF
--- a/lib/resque/plugins/uniqueness.rb
+++ b/lib/resque/plugins/uniqueness.rb
@@ -189,10 +189,12 @@ module Resque
         # And in result we ignore jobs which are already locked and should be processed.
         # We can't schedule two same jobs with `until_executing` lock.
         # That's why we sure, that all jobs, which comes from scheduler, should be processed.
+        # However enqueue_to method also calls from rufus scheduled jobs, that's why we should to check
+        # method which is specific only for delaying schedule process. This is `enqueue_next_item`
         def call_from_scheduler?
           # This path is from the `resque-scheduler` gem
           # Its not related to resque-uniqueness.
-          caller.grep(%r{lib/resque/scheduler\.rb.*enqueue}).any?
+          caller.grep(%r{lib/resque/scheduler\.rb.*enqueue_next_item}).any?
         end
 
         private

--- a/spec/resque/plugins/uniqueness_spec.rb
+++ b/spec/resque/plugins/uniqueness_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Resque::Plugins::Uniqueness do
     end
 
     context 'when call from scheduler' do
-      before { allow(UntilExecutingWorker).to receive(:caller).and_return(['lib/resque/scheduler.rb:248 #enqueue']) }
+      before { allow(UntilExecutingWorker).to receive(:caller).and_return(['lib/resque/scheduler.rb:248 #enqueue_next_item']) }
 
       it { is_expected.to be true }
     end
@@ -135,7 +135,7 @@ RSpec.describe Resque::Plugins::Uniqueness do
     before { allow(TestWorker).to receive(:caller).and_return(caller_result) }
 
     context 'when caller backtrace include scheduler enqueue method' do
-      let(:caller_result) { ['lib/resque/scheduler.rb:248 #enqueue'] }
+      let(:caller_result) { ['lib/resque/scheduler.rb:248 #enqueue_next_item'] }
 
       it { is_expected.to be true }
     end


### PR DESCRIPTION
`call_from_scheduler?` methods return `true` when we schedule jobs with Rufus scheduler. That's why he push it to queue when lock was present. And after one job starts to performing and release `queueing` lock, another job could be added to the schedule, when this schedule have the same job.