### PR TITLE
HOTFIX: log with redis key

### DIFF
--- a/lib/resque/plugins/uniqueness/base.rb
+++ b/lib/resque/plugins/uniqueness/base.rb
@@ -72,7 +72,7 @@ module Resque
         end
 
         def log(message)
-          Resque.logger.info("#{message} for #{job.payload['class']} with #{job.payload['args']}")
+          Resque.logger.info("#{message} for key: #{redis_key}")
         end
       end
     end


### PR DESCRIPTION
In this Kibana URL 
https://kibana-us.verbit.co/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now%2Fy,mode:quick,to:now%2Fy))&_a=(columns:!(json.tid,json.message),filters:!((%27$state%27:(store:appState),meta:(alias:!n,disabled:!f,index:%2772399a80-a3fa-11e9-9db8-5b00c3f29a91%27,key:query,negate:!f,type:custom,value:%27%7B%22bool%22:%7B%22minimum_should_match%22:1,%22should%22:%5B%7B%22match_phrase%22:%7B%22json.message%22:%22Queueing%20locked%20for%20TranscriptionJobCombineFilesWorker%20with%20%5Bfalse,%202116579%22%7D%7D,%7B%22match_phrase%22:%7B%22json.message%22:%22Queueing%20unlocked%20for%20TranscriptionJobCombineFilesWorker%20with%20%5Bfalse,%202116579%22%7D%7D,%7B%22match_phrase%22:%7B%22json.message%22:%22Queueing%20locking%20error%20for%20TranscriptionJobCombineFilesWorker%20with%20%5Bfalse,%202116579%22%7D%7D%5D%7D%7D%27),query:(bool:(minimum_should_match:1,should:!((match_phrase:(json.message:%27Queueing%20locked%20for%20TranscriptionJobCombineFilesWorker%20with%20%5Bfalse,%202116579%27)),(match_phrase:(json.message:%27Queueing%20unlocked%20for%20TranscriptionJobCombineFilesWorker%20with%20%5Bfalse,%202116579%27)),(match_phrase:(json.message:%27Queueing%20locking%20error%20for%20TranscriptionJobCombineFilesWorker%20with%20%5Bfalse,%202116579%27))))))),index:%2772399a80-a3fa-11e9-9db8-5b00c3f29a91%27,interval:auto,query:(language:lucene,query:%27%27),sort:!(%27@timestamp%27,desc))
we could see that job locked twice on the start, and unlocked on one time less. 
This could happen if the first two locks were had a different `redis_key`. And for one from them the lock was released, when for another - not. 
In different cases, we should at least see the `Queueing locking error` log, but this log is missed.
However, all args are the same in two messages, and mine theory couldn't be approved.
That's why I want to see more informatic `redis_key` in the logs, not just `class` and `args`.