### PR TITLE
HOTFIX: fix destroying job from queue

### DIFF
--- a/lib/resque/plugins/uniqueness/job_extension.rb
+++ b/lib/resque/plugins/uniqueness/job_extension.rb
@@ -67,10 +67,11 @@ module Resque
           end
 
           # Destroy with jobs their queueing locks
+          # TODO: move logic of releasing locks into Resque::DataStore::QueueAccess#remove_from_queue method
           def destroy(queue, klass, *args)
-            super.tap do
-              Resque::Plugins::Uniqueness.destroy(queue, klass, *args) unless Resque.inline?
-            end
+            Resque::Plugins::Uniqueness.destroy(queue, klass, *args) unless Resque.inline?
+
+            super
           end
 
           private

--- a/spec/resque/plugins/uniqueness/job_extension_spec.rb
+++ b/spec/resque/plugins/uniqueness/job_extension_spec.rb
@@ -5,6 +5,11 @@ require_relative '../../../shared_contexts/with_lock_spec'
 # We already prepended this module in `lib/resque/uniqueness.rb`
 # Therefore we will test Resque::Job class
 RSpec.describe Resque::Plugins::Uniqueness::JobExtension do
+  let(:queue) { klass.instance_variable_get(:@queue) }
+  let(:klass) {}
+  let(:args) { [] }
+  let(:uniqueness) { Resque::Job.new(queue, 'class' => klass, 'args' => args).uniqueness }
+
   describe '.create' do
     subject { Resque::Job.create(queue, klass, *args) }
 
@@ -12,7 +17,6 @@ RSpec.describe Resque::Plugins::Uniqueness::JobExtension do
     let(:lock_class) { Resque::Plugins::Uniqueness::UntilAndWhileExecuting }
     let(:queue) { :test_queue }
     let(:klass) { UntilAndWhileExecutingWorker }
-    let(:args) { [] }
 
     before { allow(Resque).to receive(:push) }
 
@@ -92,7 +96,6 @@ RSpec.describe Resque::Plugins::Uniqueness::JobExtension do
     let(:queue) { :test_queue }
     let(:job) { Resque::Job.new(queue, job_payload) }
     let(:job_payload) { {'class' => UntilAndWhileExecutingWorker, 'args' => args} }
-    let(:args) { [] }
 
     before { allow(Resque::Plugins::Uniqueness).to receive(:pop_perform_unlocked).and_return(job) }
 
@@ -116,21 +119,16 @@ RSpec.describe Resque::Plugins::Uniqueness::JobExtension do
   end
 
   describe '.destroy' do
-    subject { Resque::Job.destroy(queue, klass, *args) }
+    subject(:destroy) { Resque::Job.destroy(queue, klass, *args) }
 
-    let(:queue) { :test_queue }
     let(:klass) { UntilExecutingWorker }
     let(:args) { ['sample'] }
-    let(:data_store_instance) { instance_double(Resque::DataStore, remove_from_queue: 2) }
 
-    before do
-      allow(Resque::Job).to receive(:data_store).and_return(data_store_instance)
-      allow(Resque::Plugins::Uniqueness).to receive(:destroy)
-    end
+    before { Resque.enqueue(klass, *args) }
 
-    its_block { is_expected.to send_message(data_store_instance, :remove_from_queue).returning(2) }
+    its_block { is_expected.to change(uniqueness, :queueing_locked?).from(true).to(false) }
     its_block { is_expected.to send_message(Resque::Plugins::Uniqueness, :destroy) }
-    it { is_expected.to eq 2 }
+    it { is_expected.to eq 1 }
 
     context 'when resque inline' do
       around do |example|
@@ -139,9 +137,7 @@ RSpec.describe Resque::Plugins::Uniqueness::JobExtension do
         Resque.inline = false
       end
 
-      its_block { is_expected.to send_message(data_store_instance, :remove_from_queue).returning(2) }
       its_block { is_expected.not_to send_message(Resque::Plugins::Uniqueness, :destroy) }
-      it { is_expected.to eq 2 }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,11 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  # remove all locks
+  config.after do
+    Resque.redis.del(TestWorker::REDIS_KEY, *Resque.redis.keys('*:resque_uniqueness:*'))
+  end
 end
 
 RSpec::Matchers.define_negated_matcher :not_to_send_message, :send_message


### PR DESCRIPTION
**Description:** Fix destroying job from the queue. After `super` we resque already removes data from the queue, so we couldn't find these jobs in the queue and we couldn't release locks. So we should do it before deletion from the queue.