### PR TITLE
Add control over klass serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
   - [Until Executing](#until-executing)
   - [Until And While Executing](#until-and-while-executing)
   - [While Executing](#while-executing)
+- [Uniqueness Key Constructor](#uniqueness-key-constructor)
+  - [Uniqueness klass key](#uniqueness-klass-key)
+  - [Uniqueness filtering args](#uniqueness-filtering-args)
 - [Testing](#testing)
 - [Contributing](#contributing)
 - [License](#license)
@@ -50,7 +53,7 @@ gem install resque-uniqueness
 
 You can set a default lock type for all workers with:
 ```ruby 
-Resque::Uniqueness.default_lock_type = :while_executing
+Resque::Plugins::Uniqueness.default_lock_type = :while_executing
 ```
 By default all jobs have an `until_executing` lock type.
 
@@ -100,17 +103,38 @@ Locks when the client pushes the job to the queue. The queue will be unlocked wh
 
 With this lock type it is possible to put any number of these jobs on the queue, but as the server pops the job from the queue it will create a lock and then wait until other locks are done processing. It _looks_ like multiple jobs are running at the same time but in fact the second job will only be waiting for the first job to finish.
 
-## Filtering arguments
+## Uniqueness Key Constructor
+
+To have a control over the uniqueness key, gem provides two options:
+
+- Control over class serialization.
+- Control over arguments serialization
+
+This configuration options works perfectly together.
+
+### Uniqueness klass key
+
+Could be helpfull when you using some gem, which change base class serialization, like `resque-prioritize`, or even you want to have one lock for all children of some `TestWorker`
+
+```ruby
+def self.uniqueness_key
+  self.superclass
+end
+```
+
+### Uniqueness filtering args
+
+Overriding this method you could to choose which arguments will be used for unique lock. You could t
+provide empty array, to make lock only by class.
+Method always should returns array.
+
+Filtering arguments
 
 ```ruby
 def self.unique_args(first, second, _third)
   [first, second]
 end
 ```
-
-Overriding this method you could to choose which arguments will be used for unique lock. You could t
-provide empty array, to make lock only by class.
-Method always should returns array.
 
 ## Testing
 

--- a/lib/resque/plugins/uniqueness.rb
+++ b/lib/resque/plugins/uniqueness.rb
@@ -33,9 +33,9 @@ module Resque
     #
     # It is implemented by providing Resque callbacks where possible, and intercepting (patching)
     # the following places in Resque:
-    #   1. Resque::Uniqueness is aware of, and compatible with a resque-scheduler gem: when a job
-    #   with until_executing or until_and_while_executing lock type is tried to be scheduled,
-    #   the before_schedule hook checks it and ignores if one is already in queue.
+    #   1. Resque::Plugins::Uniqueness is aware of, and compatible with a resque-scheduler gem:
+    #   when a job with until_executing or until_and_while_executing lock type is tried to be
+    #   scheduled, the before_schedule hook checks it and ignores if one is already in queue.
     #   2. ignoring enqueue (see {Plugins::Uniqueness.before_enqueue_check_lock_availability});
     #   3. putting a job into the queue (see {JobExtension::ClassMethods.create});
     #   4. fetching the job from the queue to perform (see {JobExtension::ClassMethods.reserve});
@@ -144,6 +144,11 @@ module Resque
 
       # Helper methods and callbacks for jobs
       module ClassMethods
+        # Serialize klass for unique key
+        def uniqueness_key
+          name
+        end
+
         # Filters args which should be unique
         def unique_args(*args)
           args

--- a/lib/resque/plugins/uniqueness/base.rb
+++ b/lib/resque/plugins/uniqueness/base.rb
@@ -68,7 +68,7 @@ module Resque
         end
 
         def redis_key
-          "#{self.class::PREFIX}:#{REDIS_KEY_PREFIX}:#{Resque.encode(class: job.payload_class.to_s, args: job.payload_class.unique_args(*job.args))}"
+          "#{self.class::PREFIX}:#{REDIS_KEY_PREFIX}:#{Resque.encode(class: job.payload_class.uniqueness_key, args: job.payload_class.unique_args(*job.args))}"
         end
 
         def log(message)


### PR DESCRIPTION
Adding control over class serialization to prevent build uniqueness key with priority. (https://github.com/verbit-ai/resque-prioritize)
