### PR TITLE
HOTFIX: recovering queue only for allowed queues

### DIFF
--- a/lib/resque/plugins/uniqueness/job_extension.rb
+++ b/lib/resque/plugins/uniqueness/job_extension.rb
@@ -123,7 +123,7 @@ module Resque
 
         def scheduled?
           item = Resque.encode(class: payload_class.to_s, args: args, queue: queue)
-          Resque.redis.exists?("timestamps:#{item}")
+          Resque.redis.exists("timestamps:#{item}")
         end
 
         # NOTE: This could be a very slow operation (in case when queue has a lot of jobs), so


### PR DESCRIPTION
Use recovering queue only for the allowed queues.