### PR TITLE
HOTFIX: refactoring

### DIFF
--- a/lib/resque/plugins/uniqueness/job_extension.rb
+++ b/lib/resque/plugins/uniqueness/job_extension.rb
@@ -102,9 +102,9 @@ module Resque
         #        like me.
         def ensure_enqueue
           uniqueness.safe_try_lock_queueing unless uniqueness.queueing_locked?
+          return if scheduled? || queued?
 
-          scheduled? || queued? ||
-            Resque::Plugins::Uniqueness.push(queue, class: payload_class.to_s, args: args)
+          Resque::Plugins::Uniqueness.push(queue, class: payload_class.to_s, args: args)
         end
 
         def uniqueness

--- a/lib/resque/plugins/uniqueness/recovering_queue.rb
+++ b/lib/resque/plugins/uniqueness/recovering_queue.rb
@@ -65,6 +65,10 @@ module Resque
             .each(&method(:recover))
         end
 
+        def in_allowed_queues?(queue)
+          allowed_queues.include?(queue.to_sym)
+        end
+
         private
 
         def recover(queue)
@@ -83,10 +87,6 @@ module Resque
             Resque.redis.zrangebyscore(*args)
             Resque.redis.zremrangebyscore(*args)
           }.first.map(&Resque.method(:decode))
-        end
-
-        def in_allowed_queues?(queue)
-          allowed_queues.include?(queue.to_sym)
         end
 
         def allowed_queues

--- a/lib/resque/plugins/uniqueness/worker_extension.rb
+++ b/lib/resque/plugins/uniqueness/worker_extension.rb
@@ -8,6 +8,8 @@ module Resque
       # the recovering queue
       module WorkerExtension
         def working_on(job)
+          return super(job) unless RecoveringQueue.in_allowed_queues?(job.queue)
+
           Resque.redis.multi do
             super(job)
             RecoveringQueue.remove(job.queue, job.payload)


### PR DESCRIPTION
1. https://github.com/verbit-ai/resque-uniqueness/compare/70b0491..bb2b505#diff-23320e08502642db372b71ec8399d358a26be5e79522a02b248fb7a1a078e34eR96
Anton: Multi is only needed if it's in the enabled queue
Me: Okay

2. https://github.com/verbit-ai/resque-uniqueness/compare/70b0491..bb2b505#diff-23320e08502642db372b71ec8399d358a26be5e79522a02b248fb7a1a078e34eR118
Anton: When is it used? Seems to be a heavy operation tbh
Me: I wrote a comment

3. https://github.com/verbit-ai/resque-uniqueness/compare/70b0491..bb2b505#diff-23320e08502642db372b71ec8399d358a26be5e79522a02b248fb7a1a078e34eL125
Anton: Not needed?
Me: Yes, I should remove it before, but I figure out that it is not needed only in this pr.

4. https://github.com/verbit-ai/resque-uniqueness/compare/70b0491..bb2b505#diff-23320e08502642db372b71ec8399d358a26be5e79522a02b248fb7a1a078e34eR142
Anton: Isn't it more readable `.tap { |item| RecoveringQueue.push(queue, item) if item }` ?
Me: Yes, rewrote it.

5. https://github.com/verbit-ai/resque-uniqueness/compare/70b0491..bb2b505#diff-010471119051b5c22295eafa9eeec8b589dd0cc5f1b8e37652525af89cde7246R107
Anton: Again, why boolean operations instead of conditions?
Me: Okay.