### PR TITLE
PLAT-5239: uniqueness bug with performing lock

### DIFF
--- a/lib/resque/plugins/uniqueness/while_executing.rb
+++ b/lib/resque/plugins/uniqueness/while_executing.rb
@@ -14,8 +14,8 @@ module Resque
       class WhileExecuting < Base
         PREFIX = 'performing'
         # We should to expiring while_executing lock to prevent unexpected terminated
-        LOCK_EXPIRE_SECONDS = 4
-        LOCK_RENEWAL_WAIT_SECONDS = 2
+        LOCK_EXPIRE_SECONDS = 1.minute.to_i
+        LOCK_RENEWAL_WAIT_SECONDS = 5
 
         def perform_locked?
           should_lock_on_perform? && already_performing?


### PR DESCRIPTION
We have a problem with performing lock which releases too early. https://verbit.atlassian.net/browse/PLAT-5239 
That's why we had a duplicated transcription job which was taken from the Kaltura service. So, we made a hotfix and install a redlock in the worker body. 
I start discovering a reason and saw, that in some time I found two locking messages, without unlocking:
![image](https://user-images.githubusercontent.com/20104771/100451326-e263a500-30bf-11eb-98fe-aa10da0f0679.png)

It means, that it was unlocked manually, or in some other way. Only one way how it could be unlocked automatically - it's expiring time.
To prevent hunging performing locks after the container was terminated while performing worker, I made an expiring system: Run new thread which every two seconds update performing lock key expiration to `4` seconds. So, this bug could happen only in case, when ruby thread hung for 2 seconds, because of all system have a high load and ruby pseudo multithreading - just waiting for it chance to be triggered.
And how to fix it - just increase the interval. What I did in this pr!