### PR TITLE
PLAT-5239: uniqueness unreleased locks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,9 @@ Metrics/LineLength:
   IgnoredPatterns:
     - '\#.*' # ignore long comments
 
+Metrics/ClassLength:
+  Max: 150
+
 Style/AndOr:
   EnforcedStyle: conditionals
 

--- a/lib/resque/plugins/uniqueness.rb
+++ b/lib/resque/plugins/uniqueness.rb
@@ -12,12 +12,16 @@ require_relative 'uniqueness/job_extension'
 require_relative 'uniqueness/worker_extension'
 require_relative 'uniqueness/resque_extension'
 require_relative 'uniqueness/resque_scheduler_extension'
+require_relative 'uniqueness/data_store_extension'
+
 require_relative 'uniqueness/recovering_queue'
+require_relative 'uniqueness/jobs_extractor'
 
 Resque.prepend Resque::Plugins::Uniqueness::ResqueExtension
 Resque::Job.prepend Resque::Plugins::Uniqueness::JobExtension
 Resque::Worker.prepend Resque::Plugins::Uniqueness::WorkerExtension
 Resque.prepend Resque::Plugins::Uniqueness::ResqueSchedulerExtension
+Resque::DataStore.include Resque::Plugins::Uniqueness::DataStoreExtension
 Resque.logger = Logger.new(STDOUT, level: :info)
 
 Resque.before_first_fork(&Resque::Plugins::Uniqueness::RecoveringQueue.method(:recover_all))
@@ -59,8 +63,6 @@ module Resque
     #     # :until_executing, :while_executing, :until_and_while_executing or :none
     #     @lock_type = <desired_type>
     module Uniqueness
-      REDIS_KEY_PREFIX = 'resque_uniqueness'
-
       LOCKS = {
         until_executing: UntilExecuting,
         while_executing: WhileExecuting,

--- a/lib/resque/plugins/uniqueness/data_store_extension.rb
+++ b/lib/resque/plugins/uniqueness/data_store_extension.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Resque
+  module Plugins
+    module Uniqueness
+      # Extension for Resque::DataStore class
+      module DataStoreExtension
+        def exists?(key)
+          if @redis.respond_to?(:exists?)
+            # Supporting new redis version.
+            @redis.exists?(key)
+          else
+            # Supporting old redis version. In the new one this method was renamed to "exists?"
+            # and "exists" - returns 0 or 1, instead of true/false
+            @redis.exists(key)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/resque/plugins/uniqueness/jobs_extractor.rb
+++ b/lib/resque/plugins/uniqueness/jobs_extractor.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+module Resque
+  module Plugins
+    module Uniqueness
+      # Module to provide interface for extracting Resque::Job according to difference state
+      module JobsExtractor
+        extend self
+
+        # Locking system is a very dynamic. So, some jobs could be unlocked just now, and that's
+        # why we still could think that it locked and job will be in the `unreleased_locks` array.
+        # To be sure that you will not have any such cases, I check if lock still present at the
+        # end.
+        def with_unreleased_queueing_lock
+          (
+            (locked_items_for(UntilExecuting) - queued_items - scheduled_items) \
+            & locked_items_for(UntilExecuting)
+          ).map(&method(:item_to_job))
+        end
+
+        # Locking system is a very dynamic. So, some jobs could be unlocked just now, and that's
+        # why we still could think that it locked and job will be in the `unreleased_locks` array.
+        # To be sure that you will not have any such cases, I check if lock still present at the
+        # end.
+        def with_unreleased_performing_lock
+          (
+            (locked_items_for(WhileExecuting) - performing_items) \
+            & locked_items_for(WhileExecuting)
+          ).map(&method(:item_to_job))
+        end
+
+        def queueing_lock_garbage
+          lock_garbage_for(UntilExecuting)
+        end
+
+        def performing_lock_garbage
+          lock_garbage_for(WhileExecuting)
+        end
+
+        private
+
+        # Item is a hash which has a structure:
+        #   {'queue' => <queue_name>, 'class' => <worker_class>, 'args' => [<list of args>]}
+        def performing_items
+          Resque::Worker
+            .working
+            .map(&:job)
+            .map { |item| item['payload'].merge(item.slice('queue')) }
+        end
+
+        # Item is a hash which has a structure:
+        #   {'queue' => <queue_name>, 'class' => <worker_class>, 'args' => [<list of args>]}
+        def queued_items
+          active_queues = redis.smembers(:queues)
+
+          active_queues
+            .zip(redis.multi { active_queues.each(&redis.method(:everything_in_queue)) })
+            .to_h
+            .flat_map { |queue, items|
+              items.map(&Resque.method(:decode))
+                   .map { |item| item.merge('queue' => queue) }
+            }
+        end
+
+        # Item is a hash which has a structure:
+        #   {'queue' => <queue_name>, 'class' => <worker_class>, 'args' => [<list of args>]}
+        def scheduled_items
+          timestamps = redis.zrevrange(:delayed_queue_schedule, 0, -1)
+          items = []
+
+          timestamps.each_slice(1000) do |timestamps_part|
+            items.push(*scheduled_items_at(timestamps_part))
+            logger.info "Already processing items: #{items.count}"
+          end
+          items.map(&Resque.method(:decode))
+        end
+
+        # Item is a hash which has a structure:
+        #   {'queue' => <queue_name>, 'class' => <worker_class>, 'args' => [<list of args>]}
+        def locked_items_for(lock_class)
+          redis.smembers(lock_class.locks_storage_redis_key)
+               .then { |redis_keys| redis.mget(*redis_keys) }
+               .compact
+               .map(&Resque.method(:decode))
+        end
+
+        # Lock garbage - locks which was still in the locks set, but not actually installed (it's
+        #                mean that lock key does not present in redis)
+        # I know two expected ways how it could happen:
+        #   1. When lock key is expired. Redis automatically delete the key, but it still in the set
+        #   2. When someone delete key manually through: Resque.redis.del(redis_key)
+        def lock_garbage_for(lock_class)
+          redis_keys = redis.smembers(lock_class.locks_storage_redis_key)
+          return [] if redis_keys.empty?
+
+          redis_keys
+            .zip(redis.mget(redis_keys))
+            .to_h
+            .select { |_key, val| val.nil? }
+            .keys
+        end
+
+        def scheduled_items_at(timestamps)
+          redis.multi {
+            timestamps.each { |timestamp| redis.lrange("delayed:#{timestamp}", 0, -1) }
+          }.flatten.compact
+        end
+
+        def item_to_job(item)
+          Resque::Job.new(item['queue'], item.slice('class', 'args'))
+        end
+
+        def logger
+          Resque.logger
+        end
+
+        # Needs to customize timeout for large redis data. In other case - for large data when
+        # trying to take at least "scheduled_items" redis raise Redis::TimeoutError
+        def redis
+          @redis ||= Resque.redis
+          # Resque::DataStore.new(
+          #   Redis::Namespace.new(
+          #     Resque.redis.namespace,
+          #     redis: Redis.new(**Resque.redis._client.options, timeout: 20)
+          #   )
+          # )
+        end
+      end
+    end
+  end
+end

--- a/lib/resque/plugins/uniqueness/recovering_queue.rb
+++ b/lib/resque/plugins/uniqueness/recovering_queue.rb
@@ -66,6 +66,8 @@ module Resque
         end
 
         def in_allowed_queues?(queue)
+          return false if queue.nil?
+
           allowed_queues.include?(queue.to_sym)
         end
 

--- a/lib/resque/plugins/uniqueness/resque_scheduler_extension.rb
+++ b/lib/resque/plugins/uniqueness/resque_scheduler_extension.rb
@@ -42,7 +42,7 @@ module Resque
             # will run after hooks, but its unexpected behavior.
             Resque::Job.new(item[:queue], 'class' => item[:class], 'args' => item[:args])
                        .uniqueness
-                       .try_lock_queueing
+                       .try_lock_queueing(timestamp.to_i - Time.now.to_i)
             super
           end
         end

--- a/spec/helpers/lock_helper.rb
+++ b/spec/helpers/lock_helper.rb
@@ -5,7 +5,7 @@ module LockHelper
   include BaseHelper
   include JobHelper
 
-  REDIS_KEY_PREFIX = Resque::Plugins::Uniqueness::REDIS_KEY_PREFIX
+  REDIS_KEY_PREFIX = Resque::Plugins::Uniqueness::Base::REDIS_KEY_PREFIX
 
   def queueing_locked_items
     locked_items.fetch(:queueing, [])

--- a/spec/resque/plugins/uniqueness/job_extension_spec.rb
+++ b/spec/resque/plugins/uniqueness/job_extension_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Resque::Plugins::Uniqueness::JobExtension do
   let(:queue) { klass.instance_variable_get(:@queue) }
   let(:klass) {}
   let(:args) { [] }
-  let(:uniqueness) { Resque::Job.new(queue, 'class' => klass, 'args' => args).uniqueness }
+  let(:job) { Resque::Job.new(queue, 'class' => klass, 'args' => args) }
+  let(:uniqueness) { job.uniqueness }
 
   describe '.create' do
     subject { Resque::Job.create(queue, klass, *args) }
@@ -143,7 +144,6 @@ RSpec.describe Resque::Plugins::Uniqueness::JobExtension do
   end
 
   describe 'instance methods' do
-    let(:job) { Resque::Job.new(queue, 'class' => klass, 'args' => args) }
     let(:klass) { UntilExecutingWorker }
 
     describe '#ensure_enqueue' do
@@ -221,6 +221,30 @@ RSpec.describe Resque::Plugins::Uniqueness::JobExtension do
         encoded_payload = Resque.encode(class: job.payload_class.to_s, args: job.args, queue: queue)
         Resque.redis.scard("timestamps:#{encoded_payload}")
       end
+    end
+
+    describe '#to_encoded_item_with_queue' do
+      subject { job.to_encoded_item_with_queue }
+
+      let(:klass) { UntilExecutingWorker }
+
+      it { is_expected.to eq({class: klass, args: args, queue: queue}.to_json) }
+    end
+
+    describe '#to_encoded_item' do
+      subject { job.to_encoded_item }
+
+      let(:klass) { UntilExecutingWorker }
+
+      it { is_expected.to eq({class: klass, args: args}.to_json) }
+    end
+
+    describe '#to_uniquness_item' do
+      subject { job.to_uniquness_item }
+
+      let(:klass) { UntilExecutingWorker }
+
+      it { is_expected.to eq({class: klass, args: args}.to_json) }
     end
   end
 end

--- a/spec/resque/plugins/uniqueness/jobs_extractor_spec.rb
+++ b/spec/resque/plugins/uniqueness/jobs_extractor_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+RSpec.describe Resque::Plugins::Uniqueness::JobsExtractor do
+  describe '.with_unreleased_queueing_lock' do
+    subject { described_class.with_unreleased_queueing_lock }
+
+    let(:locked_job) { Resque::Job.new(nil, 'class' => UntilExecutingWorker, 'args' => [1]) }
+    let(:queued_locked_job) { Resque::Job.new(nil, 'class' => UntilExecutingWorker, 'args' => [2]) }
+    let(:scheduled_locked_job) { Resque::Job.new(nil, 'class' => UntilExecutingWorker, 'args' => [3]) }
+    let(:already_unlocked_job) { Resque::Job.new(nil, 'class' => UntilExecutingWorker, 'args' => [4]) }
+
+    before do
+      locked_job.uniqueness.try_lock_queueing
+
+      Resque.enqueue(queued_locked_job.payload_class, *queued_locked_job.args)
+
+      Resque.enqueue_in(10, scheduled_locked_job.payload_class, *scheduled_locked_job.args)
+
+      already_unlocked_job.uniqueness.send(:remember_lock)
+    end
+
+    it { is_expected.to eq [locked_job] }
+  end
+
+  describe '.with_unreleased_performing_lock' do
+    subject { described_class.with_unreleased_performing_lock }
+
+    let(:locked_job) { Resque::Job.new(nil, 'class' => WhileExecutingWorker, 'args' => [1]) }
+    let(:locked_working_job) { Resque::Job.new(nil, 'class' => WhileExecutingWorker, 'args' => [2]) }
+    let(:already_unlocked_job) { Resque::Job.new(nil, 'class' => WhileExecutingWorker, 'args' => [3]) }
+
+    let(:worker) { Resque::Worker.new(:all) }
+
+    before do
+      worker.startup
+      worker.working_on(locked_working_job)
+
+      locked_working_job.uniqueness.try_lock_perform
+      locked_job.uniqueness.try_lock_perform
+      already_unlocked_job.uniqueness.send(:remember_lock)
+    end
+
+    it { is_expected.to eq [locked_job] }
+  end
+
+  describe '.queueing_lock_garbage' do
+    subject { described_class.queueing_lock_garbage }
+
+    let(:job_for_garbage) { Resque::Job.new(:test, 'class' => UntilExecutingWorker, 'args' => [1]) }
+    let(:job) { Resque::Job.new(:test, 'class' => UntilExecutingWorker, 'args' => [2]) }
+
+    before do
+      Resque.enqueue(job_for_garbage.payload_class, *job_for_garbage.args)
+      Resque.redis.del(job_for_garbage.uniqueness.redis_key)
+
+      Resque.enqueue(job.payload_class, *job.args)
+    end
+
+    it { is_expected.to eq [job_for_garbage.uniqueness.redis_key] }
+  end
+
+  describe '.performing_lock_garbage' do
+    subject { described_class.performing_lock_garbage }
+
+    let(:job_for_garbage) { Resque::Job.new(:test_job, 'class' => WhileExecutingWorker, 'args' => [1]) }
+    let(:job) { Resque::Job.new(:test_job, 'class' => WhileExecutingWorker, 'args' => [2]) }
+
+    before do
+      Resque.enqueue(job_for_garbage.payload_class, *job_for_garbage.args)
+      Resque.enqueue(job.payload_class, *job.args)
+      while Resque::Job.reserve(:test_job); end
+
+      Resque.redis.del(job_for_garbage.uniqueness.redis_key)
+    end
+
+    it { is_expected.to eq [job_for_garbage.uniqueness.redis_key] }
+  end
+end

--- a/spec/resque/plugins/uniqueness/resque_scheduler_extension_spec.rb
+++ b/spec/resque/plugins/uniqueness/resque_scheduler_extension_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe Resque::Plugins::Uniqueness::ResqueSchedulerExtension do
+  let(:klass) { UntilExecutingWorker }
+  let(:args) { [1] }
+  let(:queue) { klass.instance_variable_get(:@queue) }
+  let(:job) { Resque::Job.new(queue, 'class' => klass, 'args' => args) }
+  let(:redis_key) { job.uniqueness.redis_key }
+
+  describe '.enqueue_in' do
+    subject(:schedule) { Resque.enqueue_in(seconds_to_enqueue, klass, *args) }
+
+    let(:seconds_to_enqueue) { 109_000 }
+
+    its_block {
+      is_expected.to change { Resque.redis.get(redis_key) }
+        .from(nil)
+        .to(job.to_encoded_item_with_queue)
+    }
+    its_block {
+      is_expected.to change { Resque.redis.ttl(redis_key) }
+        .to(be_within(2).of(seconds_to_enqueue + Resque::Plugins::Uniqueness::UntilExecuting::EXPIRING_TIME))
+    }
+  end
+
+  describe '.enqueue_at' do
+    subject(:schedule) { Resque.enqueue_at(enqueue_timestamp, klass, *args) }
+
+    let(:enqueue_timestamp) { Time.now.to_i + 109_000 }
+
+    its_block {
+      is_expected.to change { Resque.redis.get(redis_key) }
+        .from(nil)
+        .to(job.to_encoded_item_with_queue)
+    }
+    its_block {
+      is_expected.to change { Resque.redis.ttl(redis_key) }
+        .to(be_within(2).of(109_000 + Resque::Plugins::Uniqueness::UntilExecuting::EXPIRING_TIME))
+    }
+  end
+end

--- a/spec/resque/plugins/uniqueness/while_executing_spec.rb
+++ b/spec/resque/plugins/uniqueness/while_executing_spec.rb
@@ -27,10 +27,11 @@ RSpec.describe Resque::Plugins::Uniqueness::WhileExecuting do
   describe '#try_lock_perform' do
     subject(:call) { lock_instance.try_lock_perform }
 
-    it 'increment data in redis' do
-      call
-      expect(Resque.redis.get(redis_key)).to eq '1'
-    end
+    its_block {
+      is_expected.to change { Resque.redis.get(redis_key) }
+        .from(nil)
+        .to({class: klass, args: nil, queue: nil}.to_json)
+    }
 
     context 'when already locked' do
       around do |example|


### PR DESCRIPTION
Better tracking of system locks. 
Now - all locks store in the Redis set. So, check if the lock is broken or not - now is more simple and faster.
Introduced new service `Resque::Plugins::Uniqueness::JobsExtractor` with functions:
 - Collect all unreleased performing or queueing locks
 - Collect garbage from the Redis locks set (which mentioned above)
Also added expiration to queueing lock. To be sure that some locks will not be present a few months in the redis.