### PR TITLE
HOTFIX: fix unreleased locks fetcher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,9 @@ group :development, :test do
 end
 
 group :test do
+  gem 'ougai' # JSON logs
+  gem 'rspec', '~> 3.0'
+  gem 'rspec-its' # its(:foo) syntax
+  gem 'saharspec', '~> 0.0.5' # some syntactic sugar for RSpec
   gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,9 @@ GEM
     multi_json (1.15.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
+    oj (3.10.16)
+    ougai (1.8.5)
+      oj (~> 3.10)
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
@@ -107,6 +110,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
+  ougai
   pry
   rake (~> 12.3.3)
   resque-retry

--- a/lib/resque/plugins/uniqueness/jobs_extractor.rb
+++ b/lib/resque/plugins/uniqueness/jobs_extractor.rb
@@ -7,15 +7,29 @@ module Resque
       module JobsExtractor
         extend self
 
-        # Locking system is a very dynamic. So, some jobs could be unlocked just now, and that's
-        # why we still could think that it locked and job will be in the `unreleased_locks` array.
-        # To be sure that you will not have any such cases, I check if lock still present at the
-        # end.
-        def with_unreleased_queueing_lock
-          (
-            (locked_items_for(UntilExecuting) - scheduled_items - queued_items) \
-            & locked_items_for(UntilExecuting)
-          ).map(&method(:item_to_job))
+        # Returns array of Resque::Job with unreleased queueing lock.
+        # For large database in the first level it will returns some valid jobs. It could be a few
+        # reasons of such behaviour. For example - when it tries to select not scheduled jobs,
+        # some jobs moved to the queue at this time, release lock, reschedule and set lock again.
+        # So, lock present, job in schedule exists, but system could think that it missed.
+        # To prevent such mistakes - I decide just to run this filters few times.
+        # Every time the count of locked_items will decrease, so loop cicle will be faster and
+        # faster.
+        def with_unreleased_queueing_lock(filtering_count = 5)
+          locked_items = locked_items_for(UntilExecuting)
+          filtering_count.times do |filtering_attempt|
+            locked_items = locked_items.then(&method(:select_not_scheduled))
+                                       .-(fetch_queued_items)
+                                       .then(&method(:select_with_existing_lock))
+            break if locked_items.empty?
+
+            # Just a delay to be sure that our filter system is spread by time, and return
+            # most relevant data
+            # NOTE: "if" - to prevent sleep on the last cycle.
+            sleep 1.0 / filtering_count if filtering_attempt + 1 < filtering_count
+          end
+
+          locked_items.map(&method(:item_to_job))
         end
 
         # Locking system is a very dynamic. So, some jobs could be unlocked just now, and that's
@@ -37,6 +51,19 @@ module Resque
           lock_garbage_for(WhileExecuting)
         end
 
+        # Item is a hash which has a structure:
+        #   {'queue' => <queue_name>, 'class' => <worker_class>, 'args' => [<list of args>]}
+        def fetch_scheduled_items
+          timestamps = redis.zrevrange(:delayed_queue_schedule, 0, -1)
+          items = []
+
+          timestamps.each_slice(1000) do |timestamps_part|
+            items.push(*scheduled_items_at(timestamps_part))
+            logger.info "Already processing items: #{items.count}"
+          end
+          items.map(&Resque.method(:decode))
+        end
+
         private
 
         # Item is a hash which has a structure:
@@ -48,22 +75,32 @@ module Resque
             .map { |item| item['payload'].merge(item.slice('queue')) }
         end
 
-        # Item is a hash which has a structure:
-        #   {'queue' => <queue_name>, 'class' => <worker_class>, 'args' => [<list of args>]}
-        def scheduled_items
-          timestamps = redis.zrevrange(:delayed_queue_schedule, 0, -1)
-          items = []
+        def select_not_scheduled(locked_items)
+          return [] if locked_items.empty?
 
-          timestamps.each_slice(1000) do |timestamps_part|
-            items.push(*scheduled_items_at(timestamps_part))
-            logger.info "Already processing items: #{items.count}"
-          end
-          items.map(&Resque.method(:decode))
+          locked_items.zip(
+            redis.multi {
+              locked_items.each { |item| redis.exists?("timestamps:#{Resque.encode(item)}") }
+            }
+          ).to_h.reject { |_, is_scheduled| is_scheduled }.keys
+        end
+
+        def select_with_existing_lock(locked_items)
+          return [] if locked_items.empty?
+
+          locked_items.zip(
+            redis.multi {
+              locked_items.each { |item|
+                job = Resque::Job.new(item['queue'], item.slice('class', 'args'))
+                redis.exists?("queueing:resque_uniqueness:#{job.to_uniquness_item}")
+              }
+            }
+          ).to_h.select { |_, is_exist| is_exist }.keys
         end
 
         # Item is a hash which has a structure:
         #   {'queue' => <queue_name>, 'class' => <worker_class>, 'args' => [<list of args>]}
-        def queued_items
+        def fetch_queued_items
           active_queues = redis.smembers(:queues)
 
           active_queues
@@ -114,8 +151,6 @@ module Resque
           Resque.logger
         end
 
-        # Needs to customize timeout for large redis data. In other case - for large data when
-        # trying to take at least "scheduled_items" redis raise Redis::TimeoutError
         def redis
           Resque.redis
         end

--- a/resque-uniqueness.gemspec
+++ b/resque-uniqueness.gemspec
@@ -41,7 +41,4 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.3.3'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rspec-its' # its(:foo) syntax
-  spec.add_development_dependency 'saharspec', '~> 0.0.5' # some syntactic sugar for RSpec
 end

--- a/spec/acceptance/resque/plugins/uniqueness/jobs_extractor_spec.rb
+++ b/spec/acceptance/resque/plugins/uniqueness/jobs_extractor_spec.rb
@@ -5,15 +5,18 @@ RSpec.describe Resque::Plugins::Uniqueness::JobsExtractor, type: :acceptance do
   # unreleased lock. But it's not. So, this spec ensure that it will not happen.
   describe '.with_unreleased_queueing_lock' do
     before do
-      1000.times {
-        Resque.enqueue_in(rand(1..5), UntilExecutingWorker, SecureRandom.uuid)
+      500.times {
+        Resque.enqueue_in(rand(1..15), JobsExtractorAcceptanceWorker, SecureRandom.uuid)
       }
     end
 
-    it('is not have unreleased locks', :aggregate_failures) {
-      workers_waiter {
-        expect(described_class.with_unreleased_queueing_lock).to eq []
-      }
-    }
+    it('is not have unreleased locks', :aggregate_failures) do
+      workers_waiter do
+        expect(described_class.with_unreleased_queueing_lock(10)).to eq []
+      end
+
+      expect(described_class.with_unreleased_queueing_lock(10)).to eq []
+      expect(Resque.redis.keys('teimstamps:*')).to eq []
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'rspec'
-require 'saharspec'
-require 'rspec/its'
-require 'timecop'
+Bundler.require(:test)
+
 require 'resque/plugins/uniqueness'
 
 Resque.redis = 'localhost:6379/resque_uniqueness_test_isolated'
 Resque.logger.level = :error
+Resque::Scheduler.logger = Resque.logger
 
 require_relative 'fixtures/test_workers'
 require_relative 'acceptance/shared'


### PR DESCRIPTION
Increase speed and fix bugs in the `JobsExtractor.with_unreleased_queueing_lock` method.