### PR TITLE
HOTFIX: improve performing lock

### DIFF
--- a/lib/resque/plugins/uniqueness/jobs_extractor.rb
+++ b/lib/resque/plugins/uniqueness/jobs_extractor.rb
@@ -72,6 +72,7 @@ module Resque
           Resque::Worker
             .working
             .map(&:job)
+            .reject(&:empty?)
             .map { |item| item['payload'].merge(item.slice('queue')) }
         end
 

--- a/spec/acceptance/resque/plugins/uniqueness/jobs_extractor_spec.rb
+++ b/spec/acceptance/resque/plugins/uniqueness/jobs_extractor_spec.rb
@@ -3,16 +3,17 @@
 RSpec.describe Resque::Plugins::Uniqueness::JobsExtractor, type: :acceptance do
   # In cases when jobs moves from scheduled to queued the system could think that this job has
   # unreleased lock. But it's not. So, this spec ensure that it will not happen.
-  describe '.with_unreleased_queueing_lock' do
+  describe 'Check unreleased locks' do
     before do
       500.times {
         Resque.enqueue_in(rand(1..15), JobsExtractorAcceptanceWorker, SecureRandom.uuid)
       }
     end
 
-    it('is not have unreleased locks', :aggregate_failures) do
+    it('is not have unreleased locks', :aggregate_failures) do # rubocop:disable RSpec/ExampleLength
       workers_waiter do
         expect(described_class.with_unreleased_queueing_lock(10)).to eq []
+        expect(described_class.with_unreleased_performing_lock).to eq []
       end
 
       expect(described_class.with_unreleased_queueing_lock(10)).to eq []


### PR DESCRIPTION
If Resque::Worker does not work now on the job - on call `.job` it will return an empty hash. In this case `{}['payload'].merge(...` will raise an `undefined method "merge" for Nil class` error. 
So, I just filter out empty hashes.