### PR TITLE
HOTFIX: fix synchronize locking

### DIFF
--- a/lib/resque/plugins/uniqueness/until_executing.rb
+++ b/lib/resque/plugins/uniqueness/until_executing.rb
@@ -30,7 +30,7 @@ module Resque
           log('Queueing locked')
 
           # If value before is postive, than lock already present
-          return unless value_before.to_i.positive?
+          return unless value_before
 
           log('Queueing locking error')
           raise LockingError, 'Job is already locked on queueing'

--- a/lib/resque/plugins/uniqueness/while_executing.rb
+++ b/lib/resque/plugins/uniqueness/while_executing.rb
@@ -32,7 +32,7 @@ module Resque
           log('Performing locked')
 
           # If value before is postive, than lock already present
-          if value_before.to_i.positive?
+          if value_before
             log('Performing locking error')
             raise LockingError, 'Job is already locked on perform'
           end


### PR DESCRIPTION
Some time ago I wrote into Redis keys just a number. Using `incr`. 
So, to check if a lock was present or not, I just check the number.
After some time, I change the logic of storing into Redis key. I started to store the job serialized object. But, I forgot to change the specs for locks (in specs I still `incr` and `decr` objects). And, also, I don't change the check of the previously existing lock.
That's why It's not working. But now - should!