### PR TITLE
RND-31672: redis multi issue

### DIFF
--- a/lib/resque/plugins/uniqueness/base.rb
+++ b/lib/resque/plugins/uniqueness/base.rb
@@ -120,11 +120,8 @@ module Resque
             remember_lock
           }
           value_before, _ = result
-          if result.count < 3
-            message = "set_lock failed: #{redis_key}:#{job.to_encoded_item_with_queue}"
-            Resque.logger.info("#{message}: #{result}")
-            raise(message)
-          end
+          raise("set_lock failed: #{redis_key}:#{job.to_encoded_item_with_queue}") if result.count < 3
+
           value_before
         end
 

--- a/lib/resque/plugins/uniqueness/base.rb
+++ b/lib/resque/plugins/uniqueness/base.rb
@@ -103,11 +103,13 @@ module Resque
         end
 
         def set_lock(seconds_to_expire) # rubocop:disable Naming/AccessorMethodName
-          value_before, = redis.multi {
+          result = redis.multi {
             redis.getset(redis_key, job.to_encoded_item_with_queue)
             redis.expire(redis_key, seconds_to_expire)
             remember_lock
           }
+          value_before, _ = result
+          Resque.logger.info("set_lock failed: #{result}") if result.count < 3
           value_before
         end
 

--- a/lib/resque/plugins/uniqueness/worker_extension.rb
+++ b/lib/resque/plugins/uniqueness/worker_extension.rb
@@ -10,9 +10,9 @@ module Resque
         def working_on(job)
           return super(job) unless RecoveringQueue.in_allowed_queues?(job.queue)
 
-          Resque.redis.multi do
+          Resque.redis.multi do |multi|
             super(job)
-            RecoveringQueue.remove(job.queue, job.payload)
+            RecoveringQueue.remove(job.queue, job.payload, multi)
           end
         end
       end


### PR DESCRIPTION
Sometimes `redis.multi` doesn't return all responses from given block. Retry to execute it once again if failed