### PR TITLE
RND-34607: Resque updates and Ruby 3 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,6 @@ group :test do
   gem 'ougai' # JSON logs
   gem 'rspec', '~> 3.0'
   gem 'rspec-its' # its(:foo) syntax
-  gem 'saharspec', '~> 0.0.5' # some syntactic sugar for RSpec
+  gem 'saharspec', '~> 0.0.7' # some syntactic sugar for RSpec
   gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,13 +3,14 @@ PATH
   specs:
     resque-uniqueness (0.0.3)
       redis-namespace (~> 1.8)
-      resque (~> 2.0.0)
+      resque (~> 2.6.0)
       resque-scheduler (~> 4.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.1)
+    base64 (0.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     diff-lcs (1.4.4)
@@ -19,7 +20,7 @@ GEM
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.3)
     method_source (1.0.0)
-    mono_logger (1.1.0)
+    mono_logger (1.1.2)
     multi_json (1.15.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
@@ -34,20 +35,20 @@ GEM
       method_source (~> 1.0)
     raabro (1.3.1)
     rack (2.2.8)
-    rack-protection (3.1.0)
+    rack-protection (3.2.0)
+      base64 (>= 0.1.0)
       rack (~> 2.2, >= 2.2.4)
     rainbow (3.0.0)
     rake (12.3.3)
-    redis (4.2.2)
-    redis-namespace (1.8.0)
+    redis (4.2.5)
+    redis-namespace (1.8.2)
       redis (>= 3.0.4)
     regexp_parser (1.8.0)
-    resque (2.0.0)
+    resque (2.6.0)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
       redis-namespace (~> 1.6)
       sinatra (>= 0.9.2)
-      vegas (~> 0.1.2)
     resque-retry (1.7.3)
       resque (>= 1.25, < 3.0)
       resque-scheduler (~> 4.0)
@@ -92,18 +93,16 @@ GEM
       fugit (~> 1.1, >= 1.1.6)
     saharspec (0.0.7)
       ruby2_keywords
-    sinatra (3.1.0)
+    sinatra (3.2.0)
       mustermann (~> 3.0)
       rack (~> 2.2, >= 2.2.4)
-      rack-protection (= 3.1.0)
+      rack-protection (= 3.2.0)
       tilt (~> 2.0)
     tilt (2.3.0)
     timecop (0.9.1)
     tzinfo (2.0.2)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.7.0)
-    vegas (0.1.11)
-      rack (>= 1.0.0)
 
 PLATFORMS
   ruby
@@ -119,7 +118,7 @@ DEPENDENCIES
   rspec-its
   rubocop
   rubocop-rspec
-  saharspec (~> 0.0.5)
+  saharspec (~> 0.0.7)
   timecop
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The goal of this gem is to ensure your Resque jobs are unique. We do this by cre
 
 ## Requirements
 
-- Resque `~> 2.0.0`
+- Resque `~> 2.6.0`
 - Ruby `>= 2.3`
 
 ## Installation
@@ -144,11 +144,15 @@ You should to run resque workers:
 
 and also resque scheduler:
 
-`bundle exec resque:scheduler`
+`bundle exec rake resque:scheduler`
 
 And after it:
 
 `bundle exec rake spec`
+
+Note, you might also need to run:
+
+`redis-server --port 6378`
 
 ## Contributing
 

--- a/resque-uniqueness.gemspec
+++ b/resque-uniqueness.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'redis-namespace', '~> 1.8'
-  spec.add_dependency 'resque', '~> 2.0.0'
+  spec.add_dependency 'resque', '~> 2.6.0'
   spec.add_dependency 'resque-scheduler', '~> 4.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/spec/helpers/resque_worker_helper.rb
+++ b/spec/helpers/resque_worker_helper.rb
@@ -5,7 +5,7 @@ module ResqueWorkerHelper
   def worker_processing_jobs
     Resque::Worker.working.map(&:job).map { |job|
       job.transform_keys(&:to_sym)
-         .then { |payload:, **item| {**item, payload: payload.transform_keys(&:to_sym)} }
+         .then { |item| item.merge(payload: item[:payload].transform_keys(&:to_sym)) }
     }
   end
 end


### PR DESCRIPTION
[RND-34607 Security Updates](https://verbit.atlassian.net/browse/RND-34607) 

- update resque to 2.6.0 (and dependent libraries)
- support Ruby 3 (proc params)
- update README with new Resque version